### PR TITLE
fix peak/valley plotting to account for interpolated data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog for Curi Bio Software Development Kit
 ===============================================
 
+0.23.4 (2022-03-10)
+-------------------
+- Fix optical recording file loading
+- Change indexing into excel spreadsheet rows
+
 0.23.3 (2022-02-11)
 -------------------
 - Fix Beta 2 files analysis speed up.

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ if USE_CYTHON:
 
 setup(
     name="Pulse3D",
-    version="0.23.3",
+    version="0.23.4",
     description="Pulse3D Analysis Platform",
     url="https://github.com/CuriBio/Pulse3D",
     project_urls={"Documentation": "https://pulse3D.readthedocs.io/en/latest/"},

--- a/src/pulse3D/excel_writer.py
+++ b/src/pulse3D/excel_writer.py
@@ -45,27 +45,21 @@ def add_peak_detection_series(
     result_column = xl_col_to_name(PEAK_VALLEY_COLUMN_START + (well_index * 2) + offset)
     continuous_waveform_sheet.write(f"{result_column}1", f"{well_name} {detector_type} Values")
 
-    start_time = time_values[0] / MICRO_TO_BASE_CONVERSION
-
     for idx in indices:
         # convert peak/valley index to seconds
         idx_time = time_values[idx] / MICRO_TO_BASE_CONVERSION
-        # subtract start time
-        shifted_idx_time = idx_time - start_time
-
         uninterpolated_time_seconds = round(idx_time, 2)
-        shifted_time_seconds = round(shifted_idx_time, 2)
+
+        # we can use the peak/valley indices directly because we are using the interpolated data
+        row = idx + 2
 
         if is_optical_recording:
-            row = int(shifted_time_seconds * MICRO_TO_BASE_CONVERSION / INTERPOLATED_DATA_PERIOD_US)
-
             value = (
                 interpolated_data_function(uninterpolated_time_seconds * MICRO_TO_BASE_CONVERSION)
                 - minimum_value
             ) * MICRO_TO_BASE_CONVERSION
-        else:
-            row = shifted_time_seconds * int(1 / INTERPOLATED_DATA_PERIOD_SECONDS) + 1
 
+        else:
             interpolated_data = interpolated_data_function(
                 uninterpolated_time_seconds * MICRO_TO_BASE_CONVERSION
             )

--- a/src/pulse3D/plate_recording.py
+++ b/src/pulse3D/plate_recording.py
@@ -135,6 +135,17 @@ class WellFile:
                 "y" in str(_get_excel_metadata_value(self._excel_sheet, TWITCHES_POINT_UP_UUID)).lower()
             )
 
+            self.noise_filter_uuid = (
+                TSP_TO_DEFAULT_FILTER_UUID[self.tissue_sampling_period] if self.is_magnetic_data else None
+            )
+            self.filter_coefficients = (
+                create_filter(self.noise_filter_uuid, self.tissue_sampling_period)
+                if self.noise_filter_uuid
+                else None
+            )
+
+            self._load_magnetic_data()
+
     def _load_magnetic_data(self):
         adj_raw_tissue_reading = self[TISSUE_SENSOR_READINGS].copy()
         f = MICROSECONDS_PER_CENTIMILLISECOND if self.is_magnetic_data else MICRO_TO_BASE_CONVERSION


### PR DESCRIPTION
- optical templates were not being properly plotted due to miscalculation of Excel sheet row entries for peaks / valleys
- because we're plotting the interpolated data now, we can directly use the peak/valley indices as rows in the spreadsheet